### PR TITLE
fix: replace hardcoded wt.exe path with portable PATH lookup (#9)

### DIFF
--- a/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
+++ b/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
@@ -131,14 +131,14 @@ SetWorkingDir A_ScriptDir  ; Ensures a consistent starting directory.
 
 ^Numpad0:: ; Ctrl + Numpad 0 (NumLock on): Open Windows Terminal
 {
-    ; Open Windows Terminal
-    Run ("C:\Users\jmaffiola\AppData\Local\Microsoft\WindowsApps\wt.exe")
+    ; Open Windows Terminal via PATH (works for any user account when installed from the Store)
+    Run "wt"
 }
 
 ^NumpadIns:: ; Ctrl + Numpad 0 (NumLock off): Open Windows Terminal
 {
-    ; Open Windows Terminal
-    Run ("C:\Users\jmaffiola\AppData\Local\Microsoft\WindowsApps\wt.exe")
+    ; Open Windows Terminal via PATH (works for any user account when installed from the Store)
+    Run "wt"
 }
 
 ;---------------------------------------------------------------------


### PR DESCRIPTION
Fixes #9

## What changed
- Replaced `Run ("C:\Users\jmaffiola\AppData\Local\Microsoft\WindowsApps\wt.exe")` in both the `^Numpad0` and `^NumpadIns` hotkey handlers with `Run "wt"`.
- Windows Terminal adds itself to `PATH` when installed from the Microsoft Store, so `Run "wt"` resolves correctly for any user account without hardcoding account-specific paths.

## Why
The previous code silently failed on any machine where the user account is not `jmaffiola`. The fix makes the script portable.

## Testing note
Runtime behavior was not executed on Windows (CI runs on Linux). The change is a straightforward text substitution from a full absolute path to the `wt` alias that Windows Terminal registers on `PATH`.