### PR TITLE
fix: use A_ScriptDir absolute path when invoking markdown_to_html.py (#11)

### DIFF
--- a/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
+++ b/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
@@ -197,7 +197,7 @@ markdownToHtml(markdown) {
     ; Construct the shell command to run the Python script for conversion
     shellCommand := Format('{1} /c python "{2}" < "{3}" > "{4}"'
         , A_ComSpec
-        , ".\markdown_to_html.py"
+        , A_ScriptDir . "\markdown_to_html.py"
         , tempFile
         , tempFile . ".html")
 


### PR DESCRIPTION
Fixes #11

## What changed
In `markdownToHtml()`, replaced the relative path `".\markdown_to_html.py"` in the `Format()` call with `A_ScriptDir . "\markdown_to_html.py"`.

## Why
Although `SetWorkingDir A_ScriptDir` runs at startup, launching the script from Task Scheduler, a shortcut with a custom working directory, or any other mechanism that overrides the process working directory causes the relative lookup to fail. When the path cannot be resolved, `RunWait` silently produces no output and the function returns empty HTML with no visible error.

Using `A_ScriptDir` constructs an absolute path from the location of the `.ahk` file itself, which is invariant regardless of how or from where the script is launched.

## Testing note
Runtime behavior was not executed on Windows (CI runs on Linux). The change is a single-line substitution from a working-directory-relative path to a script-directory-absolute path.