### PR TITLE
docs: complete blank Markdown-to-HTML section in Readme.md (#12)

### DIFF
--- a/custom-keyboard-shortcuts/Readme.md
+++ b/custom-keyboard-shortcuts/Readme.md
@@ -23,7 +23,21 @@ The `custom-keyboard-shortcuts.ahk` script defines several keyboard shortcuts fo
 
 ### Markdown to HTML Conversion
 
+Use the **Ctrl + Alt + M** shortcut to convert Markdown text to HTML:
 
+1. Copy your Markdown text to the clipboard.
+2. Press **Ctrl + Alt + M**.
+3. The converted HTML is placed back on the clipboard.
+4. Paste the result wherever you need it. A tray notification confirms when the HTML is ready.
+
+The conversion is performed by `markdown_to_html.py` using the Python `markdown` library. The script is invoked via `cmd.exe` and reads from / writes to a temporary file in `%TEMP%`.
+
+**Prerequisites:**
+- Python must be on `PATH`.
+- The `markdown` library must be installed:
+  ```sh
+  pip install markdown
+  ```
 
 
 ### Functions


### PR DESCRIPTION
Fixes #12

## What changed
Filled in the empty `### Markdown to HTML Conversion` section in `custom-keyboard-shortcuts/Readme.md`. The heading existed (lines 26–28) but had no content, leaving users with no instructions for the `^!m` (Ctrl+Alt+M) shortcut.

Added:
- A numbered step-by-step usage guide (copy Markdown → press Ctrl+Alt+M → paste HTML)
- A brief explanation of how the conversion works (`markdown_to_html.py` called via `cmd.exe`, reads/writes a `%TEMP%` file)
- Prerequisites (Python on `PATH`, `pip install markdown`), cross-referenced with the existing Installation section to avoid duplication

## Testing note
Documentation-only change; no code was modified.