### PR TITLE
feat: remove unused runWaitOne function (#13)

### DIFF
--- a/custom-keyboard-shortcuts/Readme.md
+++ b/custom-keyboard-shortcuts/Readme.md
@@ -50,10 +50,6 @@ This function pastes data to the active window while preserving the current clip
 
 This function converts a given Markdown string to HTML using a Python script.
 
-#### `runWaitOne(command, input, &output)`
-
-This function runs a command and captures the output in a single step.
-
 ## Requirements
 
 - AutoHotkey v2.0

--- a/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
+++ b/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
@@ -221,20 +221,3 @@ markdownToHtml(markdown) {
     return html
 }
 
-/**
- * @name runWaitOne
- * @description This function runs a command and captures the output in a single step.
- * 
- * @param command The command to run.
- * @param input The input to pass to the command.
- * @param output The variable to store the output in.
- */
-runWaitOne(command, input, &output) {
-    ; Run the command and capture the output
-    shell := ComObject("WScript.Shell")
-    exec := shell.Exec(command)
-    exec.StdIn.Write(input)
-    exec.StdIn.Close()
-    while !exec.StdOut.AtEndOfStream
-        output .= exec.StdOut.ReadAll()
-}


### PR DESCRIPTION
Fixes #13

## What changed
Deleted the `runWaitOne(command, input, &output)` function from `custom-keyboard-shortcuts.ahk` and its corresponding entry from the `Readme.md` Functions section.

## Why
The function was never called anywhere in the repository. Dead code is misleading — it implies the function is maintained and tested, and it increases the surface area that reviewers and future contributors need to understand.

If a `WScript.Shell`-based command runner is needed in the future, it can be reintroduced at that time with proper integration and test coverage.

## Testing note
No runtime behavior changed (the function was unreachable). Verified by `grep` that `runWaitOne` has no remaining call sites in the repo.