### PR TITLE
docs: add root README.md and GitHub repo description (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# AutoHotkey Scripts
+
+A collection of AutoHotkey v2 scripts for Windows that add custom keyboard shortcuts and productivity utilities.
+
+## Requirements
+
+- [AutoHotkey v2.0](https://www.autohotkey.com/) — these scripts target AHK v2 exclusively and are not compatible with AHK v1.
+- Python 3 (required by the Markdown-to-HTML feature) with the `markdown` library:
+  ```sh
+  pip install markdown
+  ```
+
+## Scripts
+
+### [`custom-keyboard-shortcuts/`](custom-keyboard-shortcuts/)
+
+The main script collection. See [`custom-keyboard-shortcuts/Readme.md`](custom-keyboard-shortcuts/Readme.md) for full documentation.
+
+**Shortcuts at a glance:**
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl + Shift + D` | Paste the current date and time |
+| `Ctrl + Shift + T` | Paste the current time |
+| `Ctrl + Alt + M` | Convert clipboard Markdown to HTML |
+| `Ctrl + Numpad 0` | Open Windows Terminal |
+| `CapsLock` (hold) | Hyper key (Ctrl + Shift + Alt) |
+| `Hyper + H` | Convert selected text to UPPERCASE and paste |
+
+## Installation
+
+1. Install [AutoHotkey v2.0](https://www.autohotkey.com/).
+2. Clone this repository:
+   ```sh
+   git clone https://github.com/J-MaFf/AutoHotkey-Scripts.git
+   ```
+3. (Optional) Install Python dependencies for Markdown conversion:
+   ```sh
+   pip install markdown
+   ```
+4. Double-click `custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk` to run, or add it to your Windows startup folder.
+
+## License
+
+MIT


### PR DESCRIPTION
Fixes #14

## What changed

### Root `README.md` (new file)
Added a top-level `README.md` that GitHub renders on the repository landing page. It includes:
- One-line project description (AutoHotkey v2, Windows, keyboard shortcuts + utilities)
- Requirements section (AHK v2.0 + Python 3 / `markdown` library for `^!m`)
- Scripts section linking to `custom-keyboard-shortcuts/` and its `Readme.md`
- At-a-glance shortcuts table covering all six hotkeys
- Installation steps (install AHK v2, clone, optional `pip install markdown`, double-click to run)
- MIT license reference

### GitHub repository description (metadata)
Ran `gh repo edit J-MaFf/AutoHotkey-Scripts --description "..."` to set:
> AutoHotkey v2 scripts for Windows — custom keyboard shortcuts, Markdown-to-HTML conversion, and productivity utilities

This description appears in GitHub search results and on the repo card before a visitor opens any file.

## Testing note
Documentation and metadata change only; no script code was modified.