### PR TITLE
2026 review: AutoHotkey-Scripts fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# AutoHotkey Scripts
+
+A collection of AutoHotkey v2 scripts for Windows that add custom keyboard shortcuts and productivity utilities.
+
+## Requirements
+
+- [AutoHotkey v2.0](https://www.autohotkey.com/) — these scripts target AHK v2 exclusively and are not compatible with AHK v1.
+- Python 3 (required by the Markdown-to-HTML feature) with the `markdown` library:
+  ```sh
+  pip install markdown
+  ```
+
+## Scripts
+
+### [`custom-keyboard-shortcuts/`](custom-keyboard-shortcuts/)
+
+The main script collection. See [`custom-keyboard-shortcuts/Readme.md`](custom-keyboard-shortcuts/Readme.md) for full documentation.
+
+**Shortcuts at a glance:**
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl + Shift + D` | Paste the current date and time |
+| `Ctrl + Shift + T` | Paste the current time |
+| `Ctrl + Alt + M` | Convert clipboard Markdown to HTML |
+| `Ctrl + Numpad 0` | Open Windows Terminal |
+| `CapsLock` (hold) | Hyper key (Ctrl + Shift + Alt) |
+| `Hyper + H` | Convert selected text to UPPERCASE and paste |
+
+## Installation
+
+1. Install [AutoHotkey v2.0](https://www.autohotkey.com/).
+2. Clone this repository:
+   ```sh
+   git clone https://github.com/J-MaFf/AutoHotkey-Scripts.git
+   ```
+3. (Optional) Install Python dependencies for Markdown conversion:
+   ```sh
+   pip install markdown
+   ```
+4. Double-click `custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk` to run, or add it to your Windows startup folder.
+
+## License
+
+MIT

--- a/custom-keyboard-shortcuts/Readme.md
+++ b/custom-keyboard-shortcuts/Readme.md
@@ -23,7 +23,21 @@ The `custom-keyboard-shortcuts.ahk` script defines several keyboard shortcuts fo
 
 ### Markdown to HTML Conversion
 
+Use the **Ctrl + Alt + M** shortcut to convert Markdown text to HTML:
 
+1. Copy your Markdown text to the clipboard.
+2. Press **Ctrl + Alt + M**.
+3. The converted HTML is placed back on the clipboard.
+4. Paste the result wherever you need it. A tray notification confirms when the HTML is ready.
+
+The conversion is performed by `markdown_to_html.py` using the Python `markdown` library. The script is invoked via `cmd.exe` and reads from / writes to a temporary file in `%TEMP%`.
+
+**Prerequisites:**
+- Python must be on `PATH`.
+- The `markdown` library must be installed:
+  ```sh
+  pip install markdown
+  ```
 
 
 ### Functions

--- a/custom-keyboard-shortcuts/Readme.md
+++ b/custom-keyboard-shortcuts/Readme.md
@@ -50,10 +50,6 @@ This function pastes data to the active window while preserving the current clip
 
 This function converts a given Markdown string to HTML using a Python script.
 
-#### `runWaitOne(command, input, &output)`
-
-This function runs a command and captures the output in a single step.
-
 ## Requirements
 
 - AutoHotkey v2.0

--- a/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
+++ b/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
@@ -221,20 +221,3 @@ markdownToHtml(markdown) {
     return html
 }
 
-/**
- * @name runWaitOne
- * @description This function runs a command and captures the output in a single step.
- * 
- * @param command The command to run.
- * @param input The input to pass to the command.
- * @param output The variable to store the output in.
- */
-runWaitOne(command, input, &output) {
-    ; Run the command and capture the output
-    shell := ComObject("WScript.Shell")
-    exec := shell.Exec(command)
-    exec.StdIn.Write(input)
-    exec.StdIn.Close()
-    while !exec.StdOut.AtEndOfStream
-        output .= exec.StdOut.ReadAll()
-}

--- a/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
+++ b/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
@@ -197,7 +197,7 @@ markdownToHtml(markdown) {
     ; Construct the shell command to run the Python script for conversion
     shellCommand := Format('{1} /c python "{2}" < "{3}" > "{4}"'
         , A_ComSpec
-        , ".\markdown_to_html.py"
+        , A_ScriptDir . "\markdown_to_html.py"
         , tempFile
         , tempFile . ".html")
 

--- a/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
+++ b/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
@@ -105,16 +105,24 @@ SetWorkingDir A_ScriptDir  ; Ensures a consistent starting directory.
     ; Add delay to ensure window is ready
     Sleep(100)
 
-    ; Try to paste with retry logic for compatibility
+    ; Try to paste with retry logic — verify each attempt by checking
+    ; whether the clipboard still holds the uppercase text after paste.
+    ; Most applications clear or replace clipboard contents on a successful
+    ; paste; if it is unchanged we assume the paste failed and retry.
     pasteSuccess := false
     loop 3 {  ; Try up to 3 times
+        A_Clipboard := uppercase  ; Refresh clipboard in case a prior attempt cleared it
+        ClipWait(1)               ; Ensure clipboard is ready before sending
         Send("^v")
-        Sleep(100)  ; Wait to see if paste worked
-        if (A_Index < 3) {
-            Sleep(50)  ; Additional delay between retries
+        Sleep(150)  ; Give the target application time to consume the paste
+        if (A_Clipboard != uppercase) {
+            ; Clipboard was changed/consumed — paste succeeded
+            pasteSuccess := true
+            break
         }
-        pasteSuccess := true
-        break
+        if (A_Index < 3) {
+            Sleep(100)  ; Brief back-off before retrying
+        }
     }
 
     ; Restore original clipboard

--- a/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
+++ b/custom-keyboard-shortcuts/custom-keyboard-shortcuts.ahk
@@ -131,14 +131,14 @@ SetWorkingDir A_ScriptDir  ; Ensures a consistent starting directory.
 
 ^Numpad0:: ; Ctrl + Numpad 0 (NumLock on): Open Windows Terminal
 {
-    ; Open Windows Terminal
-    Run ("C:\Users\jmaffiola\AppData\Local\Microsoft\WindowsApps\wt.exe")
+    ; Open Windows Terminal via PATH (works for any user account when installed from the Store)
+    Run "wt"
 }
 
 ^NumpadIns:: ; Ctrl + Numpad 0 (NumLock off): Open Windows Terminal
 {
-    ; Open Windows Terminal
-    Run ("C:\Users\jmaffiola\AppData\Local\Microsoft\WindowsApps\wt.exe")
+    ; Open Windows Terminal via PATH (works for any user account when installed from the Store)
+    Run "wt"
 }
 
 ;---------------------------------------------------------------------


### PR DESCRIPTION
Aggregated 2026 code-review fixes for manual review. Do not merge until reviewed.

Fixes #9
Fixes #10
Fixes #11
Fixes #12
Fixes #13
Fixes #14

## Issues addressed
- #9 — Replace hardcoded `wt.exe` path (`C:\Users\jmaffiola\...`) with portable `Run "wt"` (Windows Terminal on PATH)
- #10 — Fix paste-retry loop in `^+!h` that unconditionally broke on first iteration; replaced with clipboard-comparison success check
- #11 — Use `A_ScriptDir . "\markdown_to_html.py"` instead of relative `".\markdown_to_html.py"` in `markdownToHtml()` to avoid failures when working directory differs from script directory
- #12 — Fill the empty `### Markdown to HTML Conversion` section in `Readme.md` with step-by-step usage instructions
- #13 — Delete unused `runWaitOne` function (never called) from the .ahk file and its Readme.md entry
- #14 — Add root `README.md` with project overview, shortcuts table, and installation guide; set GitHub repository description via `gh repo edit`

## Runtime note
AutoHotkey cannot run on Linux. All `.ahk` changes were verified by code inspection only. Runtime behavior was not executed on Windows.